### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Dan-J-D/wgmesh/security/code-scanning/1](https://github.com/Dan-J-D/wgmesh/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow to explicitly restrict the `GITHUB_TOKEN` permissions. Since the workflow only builds and tests the code, the minimum required permission is `contents: read`. This ensures that the workflow has access to the repository contents but cannot make any modifications. 

The `permissions` block will be added directly below the `name: Go` line in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
